### PR TITLE
Add WooCommerce onboarding setup methods

### DIFF
--- a/includes/integrations/class.WooCommerce.php
+++ b/includes/integrations/class.WooCommerce.php
@@ -720,4 +720,37 @@ class MethodWooCommerce extends \WC_Payment_Gateway_CC {
 		}
 	}
 
+	/**
+	 * Get the settings keys required for setup during onboarding.
+	 *
+	 * @return array
+	 */
+	public function get_required_settings_keys() {
+		return array(
+			'eway_api_key',
+			'eway_password',
+		);
+	}
+
+	/**
+	 * Get help text to display during onboarding setup.
+	 *
+	 * @return string
+	 */
+	public function get_setup_help_text() {
+		return sprintf(
+			__( 'Your API details can be obtained from your <a href="%s" target="_blank">eWAY account</a>.', 'eway-payment-gateway' ),
+			'https://www.eway.com.au/',
+		);
+	}
+
+	/**
+	 * Determine if the gateway still requires setup.
+	 *
+	 * @return bool
+	 */
+	public function needs_setup() {
+		return ! $this->get_option( 'eway_api_key' ) || ! $this->get_option( 'eway_password' );
+	}
+
 }


### PR DESCRIPTION
Adds the setup methods for WooCommerce onboarding.

### Screenshots

<img width="707" alt="Screen Shot 2021-06-02 at 6 09 57 PM" src="https://user-images.githubusercontent.com/10561050/120559168-8b23f180-c3ce-11eb-9858-89787cdfa0bf.png">


### Testing

1. Follow the testing instructions in https://github.com/woocommerce/woocommerce-admin/pull/7108
2. Sanity check that `eway_api_key` and `eway_password` are the required options for setup.